### PR TITLE
1.1.2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,25 +2,25 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: 'tsconfig.json',
-    sourceType: 'module',
+    sourceType: 'module'
   },
   plugins: ['@typescript-eslint/eslint-plugin'],
   extends: [
     'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
+    'plugin:prettier/recommended'
   ],
   root: true,
   env: {
     node: true,
-    jest: true,
+    jest: true
   },
   ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
-  },
+  }
 };

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,5 +1,8 @@
 # BlunderBot Twitch Commands
 
+#### NOTE: Channel redemptions and Bits may change depending on the streamer using BlunderBot. The following currently apply to [NateBrady23](https://twitch.tv/natebrady23)'s stream.
+
+
 :people_hugging: - Follower only
 
 :gem: - Subscriber only
@@ -19,7 +22,11 @@
 
 `!chat <message>` :people_hugging:: Asks BlunderBot a question.
 
+`!clock`: BlunderBot announces that the streamer is low on time.
+
 `!crown <name>`: Change my crown while I'm playing. Ex. `!crown tophat`
+
+`!dadjoke`: BlunderBot tells a dad joke.
 
 `!daily`: Displays the lichess daily puzzle link
 
@@ -37,6 +44,8 @@
 
 `!highlight <squares> <color>`: Highlights squares on the board. Ex. `!highlight e4e5 red`
 
+`!image <description>`:gem:: Displays an image based on the description on the stream and sends that image to the galler channel in Discord..
+
 `!king <name>`: Change my king while I'm playing. Ex. `!king cry`
 
 `!opening <gameId>`: Displays the opening of <gameId>. If no <gameId> is provided, it will display the opening of the current game.
@@ -53,7 +62,11 @@
 
 `!redsox`: Displays the current score of the Red Sox game
 
+`!resign`: BlunderBot announces a user thinks the streamer should resign the current game.
+
 `!shorts`: Displays the latest YouTube shorts link.
+
+`!skipsong`: BlunderBot announces that a user would like to skip the current song.
 
 `!subsribers`: Displays the number of subscribers NateBrady23 has on Twitch. Also: `!subs`
 
@@ -65,39 +78,13 @@
 
 `!translate <message>` :people_hugging:: Will translate the message to English.
 
+`!trophy`: BlunderBot announces that the streamer has won a rosen trophy.
+
 `!tts <message>` :gem::five: : BlunderBot will read the message. Donating 100 bits or more will also get BlunderBot to read the message.
 
 `!uptime`: Displays how long the current stream has been live.
 
 `!vchat <message>` :gem::three: : Asks BlunderBot a question but BlunderBot responds with voice instead of text.
-
-### Channel Redemptions
-
-`Buy a Square (5)`: For only 5 BlunderBucks (channel points), you can buy a square on the board and your name will stay there for the rest of the stream.
-
-`Change my opponent's rating (100)`: Allows you to change the rating displayed for my opponent in the current game.
-
-`Challenge Me (350)`: On viewer challenge nights, enter the queue by redeeming this.
-
-`Play a gif on the board (1000)`: Where subscribers have the `!gif` command, anyone can use this redemption to play a gif on the board.
-
-`Run a poll (1000)`: Allows anyone to run a poll on the channel.
-
-`Title me on lichess (7000)`: Adds a title beside your name anytime your name appears on stream on lichess.org. Can't be an actual title. Use the `!titles` command to see who is titled on the stream. This title doesn't expire.
-
-`Create me an opponent king (15000)`: I'll create a king for you so you can use the `!opp <name>` command.
-
-
-### Bits
-
-`cheer69`: BlunderBot changes my king and the opponent king to characters that otherwise can't be chosen.
-
-`cheer314`: ^ Does the same with different characters.
-
-`cheer420`: ^ Does the same with different characters.
-
-`cheer100`: 100 bits or more and BlunderBot will read the attached message and play a longer clip of the bits alert.
-
 
 ### Mod Commands
 
@@ -111,19 +98,30 @@
 
 `poll <message>`: BlunderBot will start a poll with some choices based on the message. Use like: `!poll favorite chess opening`
 
+### Channel Redemptions
 
-### Personal Mod Commands
+`Buy a Square`: You can buy a square on the board and your name will stay there for the rest of the stream.
 
-`clock`: This is a Mammali-only command!
+`Change my opponent's rating`: Allows you to change the rating displayed for my opponent in the current game.
 
-`dadjoke`: This is a northcarolinadan-only command!
+`Challenge Me`: On viewer challenge nights, enter the queue by redeeming this.
 
-`skipsong`: This is a Dayzo-only command!
+`Play a gif on the board`: Where subscribers have the `!gif` command, anyone can use this redemption to play a gif on the board.
 
-`trophy`: This a Trevlar-only command!
+`Run a poll`: Allows anyone to run a poll on the channel.
 
-### Simple Commands
+`Title me on lichess`: Adds a title beside your name anytime your name appears on stream on lichess.org. Can't be an actual title. Use the `!titles` command to see who is titled on the stream. This title doesn't expire.
 
-Each of these commands display a simple static message in chat.
+`Create me an opponent king`: I'll create a king for you so you can use the `!opp <name>` command.
 
-`afm`, `backseat`, `beholdg4`, `blunderbot`, `blunderreport`, `bm`, `em`, `chess`, `discord`, `dm`, `fauxtog`, `insubordinate`, `lurk`, `merch`, `onlychess`, `onlyfans`, `prime`, `resign`, `rip`, `rosen`, `rm`, `streamlabs`, `team`, `tess`, `tiktok`, `tip`, `youtube`
+`Create my own command`: I'll create a command that only you can use on the stream.
+
+### Bits
+
+`cheer69`: BlunderBot changes my king and the opponent king to characters that otherwise can't be chosen.
+
+`cheer314`: ^ Does the same with different characters.
+
+`cheer420`: ^ Does the same with different characters.
+
+`cheer100`: 100 bits or more and BlunderBot will read the attached message and play a longer clip of the bits alert.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,19 @@
 # Release Notes
 
+### 1.1.2 (2023-12-30)
+
+#### Bug Fixes
+
+- There was at least one command in the `owner-commands` dir that I forgot to add `ownerOnly: true` to, so now all commands in the owner directory and mod directory will automatically get `ownerOnly: true` and `modOnly: true` respectively.
+- Fix `any` usage in `command.types.d.ts` to properly type services in command files.
+- Fix an issue with `!bits` where users weren't getting added to the contributions to be thanked at the end of the stream.
+- Fix an issue with subCommands being wrong in the types file.
+
+#### Features
+
+- Added a `!resetlimits` owner command. Without an arg, it resets the limits on all commands. Or you can reset the limits on one command like `!resetlimits image`.
+- Added a `!resign` command to tell the streamer it's time to end the madness. I added this as a user restricted command in the config.
+
 ### 1.1.1 (2023-12-30)
 
 #### Bug Fixes

--- a/config.yml.sample
+++ b/config.yml.sample
@@ -35,6 +35,7 @@ twitch:
   userRestrictedCommands:
     clock: ["mammali77"]
     dadjoke: ["northcarolinadan"]
+    resign: ["strobex_gaming"]
     skipsong: ["loldayzo"]
     trophy: ["trevlar_"]
   # These commands are limited to followers only
@@ -263,9 +264,6 @@ messageCommands:
 
   prime:
     message: "If you have Amazon Prime, you can subscribe and support the channel for free!"
-
-  resign:
-    message: "It is time to end this madness!"
 
   rosen:
     aliases:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blunderot",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "BlunderBot came here to drink milk and blunder and he's all out of milk.",
   "author": "Nate Brady <https://twitch.tv/NateBrady23>",
   "private": true,

--- a/src/app.gateway.ts
+++ b/src/app.gateway.ts
@@ -18,20 +18,20 @@ export class AppGateway
 
   private sockets = [];
 
-  afterInit(_server: any): any {
+  afterInit(_server: unknown): undefined {
     this.logger.log('Initialized!');
   }
 
-  handleConnection(client: Socket, ..._args): any {
+  handleConnection(client: Socket) {
     this.logger.log(`App-Socket Client connected: ${client.id}`);
     this.sockets.push(client);
   }
 
-  handleDisconnect(client: Socket): any {
+  handleDisconnect(client: Socket) {
     this.logger.log(`App-Socket Client disconnected: ${client.id}`);
   }
 
-  public sendDataToSockets(event, data): any {
+  public sendDataToSockets(event: string, data: unknown) {
     this.logger.log(`Sending ${event} event to sockets.`);
     this.sockets.forEach((socket: Socket) => {
       if (socket.connected) {
@@ -39,15 +39,5 @@ export class AppGateway
         socket.emit(event, data);
       }
     });
-  }
-
-  public sendDataToOneSocket(event, data): any {
-    this.logger.log(`Sending ${event} event to a single socket.`);
-    for (let i = 0; i < this.sockets.length; i++) {
-      if (this.sockets[i].connected) {
-        this.sockets[i].emit(event, data);
-        break;
-      }
-    }
   }
 }

--- a/src/command/command.service.ts
+++ b/src/command/command.service.ts
@@ -150,7 +150,7 @@ export class CommandService {
 
     if (
       ctx.platform === 'twitch' &&
-      CONFIG.twitch.subsCommands.includes(cmd.name) &&
+      CONFIG.twitch.subCommands.includes(cmd.name) &&
       !ctx.tags.subscriber
     ) {
       ctx.botSpeak(

--- a/src/command/command.types.d.ts
+++ b/src/command/command.types.d.ts
@@ -1,59 +1,76 @@
-interface CommandRunFuncOptions {
-  services: CommandServices;
-  commandState: CommandState;
-  commands: Command[];
-}
-interface CommandRunFunc {
-  (ctx: Context, obj: CommandRunFuncOptions): boolean | Promise<boolean>;
-}
+import { TwitchGateway } from '../twitch/twitch.gateway';
+import { TwitchService } from '../twitch/twitch.service';
+import { TwitchCustomRewardsService } from '../twitch/twitch.custom-rewards';
+import { OpenaiService } from '../openai/openai.service';
+import { LichessService } from '../lichess/lichess.service';
+import { GiphyService } from '../giphy/giphy.service';
+import { DiscordService } from '../discord/discord.service';
+import { BrowserService } from '../browser/browser.service';
+import { AppGateway } from '../app.gateway';
 
-interface Command {
-  name: string;
-  // Deprecated?
-  queued?: boolean;
-  run: CommandRunFunc;
-  help?: string;
-  coolDown?: number;
-  modOnly?: boolean;
-  ownerOnly?: boolean;
-  // If true, the twitch stream must be live for the command to run
-  requiresLive?: boolean;
-  // timestamp
-  lastRun?: number;
-  aliases?: string[];
-  platforms: Platforms[];
-}
+declare global {
+  interface CommandRunFuncOptions {
+    services: CommandServices;
+    commandState: CommandState;
+    commands: Command[];
+  }
 
-interface CommandServices {
-  appGateway: any;
-  browserService: any;
-  discordService: any;
-  giphyService: any;
-  lichessService: any;
-  openaiService: any;
-  twitchCustomRewardsService: any;
-  twitchGateway: any;
-  twitchService: any;
-}
+  interface CommandRunFunc {
+    (ctx: Context, obj: CommandRunFuncOptions): boolean | Promise<boolean>;
+  }
 
-interface CommandState {
-  arena: string;
-  first: string;
-  isLive: boolean;
-  limitedCommands: any;
-  toggledOffCommands: string[];
-  killedCommands: string[];
-  blunderBotPersonality: string;
-  blunderbotVoice: string;
-  ephemeralCommands: any;
-  cbanUsers: string[];
-  wouldBeCommands: any;
-  contributions: any;
-  heartRateHigh: number;
-}
+  interface Command {
+    name: string;
+    // Deprecated?
+    queued?: boolean;
+    run: CommandRunFunc;
+    help?: string;
+    coolDown?: number;
+    modOnly?: boolean;
+    ownerOnly?: boolean;
+    // If true, the twitch stream must be live for the command to run
+    requiresLive?: boolean;
+    // timestamp
+    lastRun?: number;
+    aliases?: string[];
+    platforms: Platforms[];
+  }
 
-interface MessageCommand {
-  aliases?: string[];
-  hideFromList?: boolean;
-  message: string;
+  interface CommandServices {
+    appGateway: AppGateway;
+    browserService: BrowserService;
+    discordService: DiscordService;
+    giphyService: GiphyService;
+    lichessService: LichessService;
+    openaiService: OpenaiService;
+    twitchCustomRewardsService: TwitchCustomRewardsService;
+    twitchGateway: TwitchGateway;
+    twitchService: TwitchService;
+  }
+
+  interface CommandState {
+    arena: string;
+    first: string;
+    isLive: boolean;
+    limitedCommands: { [key: string]: { [key: string]: number } };
+    toggledOffCommands: string[];
+    killedCommands: string[];
+    blunderBotPersonality: string;
+    blunderbotVoice: string;
+    ephemeralCommands: { [key: string]: string };
+    cbanUsers: string[];
+    wouldBeCommands: { [key: string]: string };
+    contributions: {
+      bits: { [key: string]: number };
+      subs: { [key: string]: boolean };
+      raids: { [key: string]: boolean };
+    };
+    heartRateHigh: number;
+  }
+
+  interface MessageCommand {
+    aliases?: string[];
+    hideFromList?: boolean;
+    message: string;
+  }
 }

--- a/src/command/commands/help.ts
+++ b/src/command/commands/help.ts
@@ -14,7 +14,6 @@ const command: Command = {
       !cmd ||
       !cmd.help ||
       !cmd.platforms.includes(ctx.platform) ||
-      CONFIG.killedCommands.includes(commandName) ||
       commandState.killedCommands.includes(commandName)
     ) {
       ctx.botSpeak(`There is no help available for that command.`);

--- a/src/command/commands/index.ts
+++ b/src/command/commands/index.ts
@@ -22,17 +22,25 @@ export const commands = {
   ...messageCommands
 };
 
+const MOD_DIR = './src/command/mod-commands';
+const OWNER_DIR = './src/command/owner-commands';
+
 const dirImports = [
   ['./src/command/commands', './'],
-  ['./src/command/mod-commands', '../mod-commands/'],
-  ['./src/command/owner-commands', '../owner-commands/']
+  [MOD_DIR, '../mod-commands/'],
+  [OWNER_DIR, '../owner-commands/']
 ];
 
 dirImports.forEach((dir) => {
   readdirSync(dir[0]).forEach((file) => {
     const fileName = file.split('.')[0];
-    if (fileName !== 'index' && fileName !== 'messageCommands') {
+    if (fileName !== 'index') {
       commands[fileName] = require(`${dir[1]}${fileName}`).default;
+      if (dir[0] === MOD_DIR) {
+        commands[fileName].modOnly = true;
+      } else if (dir[0] === OWNER_DIR) {
+        commands[fileName].ownerOnly = true;
+      }
     }
   });
 });

--- a/src/command/commands/resign.ts
+++ b/src/command/commands/resign.ts
@@ -1,0 +1,17 @@
+import { Platform } from '../../enums';
+import { removeSymbols } from '../../utils/utils';
+
+const command: Command = {
+  name: 'resign',
+  platforms: [Platform.Twitch],
+  run: async (ctx, { services }) => {
+    void services.twitchService.ownerRunCommand(
+      `!tts ${removeSymbols(
+        ctx.tags['display-name']
+      )} wants you to know that it's time to end this madness.`
+    );
+    return true;
+  }
+};
+
+export default command;

--- a/src/command/mod-commands/accept.ts
+++ b/src/command/mod-commands/accept.ts
@@ -3,7 +3,6 @@ import { CONFIG } from '../../config/config.service';
 
 const command: Command = {
   name: 'accept',
-  modOnly: true,
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx, { services }) => {
     const team = CONFIG.lichess.teamId;

--- a/src/command/mod-commands/add.ts
+++ b/src/command/mod-commands/add.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'add',
-  modOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     commandState.ephemeralCommands[ctx.args[0]] = ctx.body.replace(

--- a/src/command/mod-commands/cancel.ts
+++ b/src/command/mod-commands/cancel.ts
@@ -8,7 +8,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'cancel',
-  modOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     const currPoll = await services.twitchService.helixOwnerApiCall(

--- a/src/command/mod-commands/gpredict.ts
+++ b/src/command/mod-commands/gpredict.ts
@@ -11,7 +11,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'gpredict',
-  modOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     let items = getItemsBetweenDelimiters(ctx.body, '"');

--- a/src/command/mod-commands/poll.ts
+++ b/src/command/mod-commands/poll.ts
@@ -3,7 +3,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'poll',
-  modOnly: true,
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx, { services }) => {
     let question: any = ctx.body;

--- a/src/command/mod-commands/shoutout.ts
+++ b/src/command/mod-commands/shoutout.ts
@@ -5,7 +5,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'shoutout',
-  modOnly: true,
   aliases: ['so'],
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx: Context, { services }) => {

--- a/src/command/mod-commands/violators.ts
+++ b/src/command/mod-commands/violators.ts
@@ -4,7 +4,6 @@ import { CONFIG } from '../../config/config.service';
 
 const command: Command = {
   name: 'violators',
-  modOnly: true,
   platforms: [Platform.Discord],
   run: async (ctx) => {
     const teamId = CONFIG.lichess.teamId;

--- a/src/command/owner-commands/alert.ts
+++ b/src/command/owner-commands/alert.ts
@@ -6,7 +6,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'alert',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/autochat.ts
+++ b/src/command/owner-commands/autochat.ts
@@ -6,7 +6,6 @@ let currentInterval = null;
 
 const command: Command = {
   name: 'autochat',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     // Always clearing the interval so multiple "on"s don't stack and anything else shuts it off

--- a/src/command/owner-commands/bits.ts
+++ b/src/command/owner-commands/bits.ts
@@ -7,44 +7,45 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'bits',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
-  run: async (ctx, { services }) => {
+  run: async (ctx, { services, commandState }) => {
     return queue.enqueue(async function () {
-      try {
-        let body: any = ctx.body;
-        // To test bits like: !bits 420
-        if (body.match(/^\d{1,4}$/g)) {
-          body = '{ "bits": ' + body + ' }';
-        }
-        body = JSON.parse(body);
-        const bits = parseInt(body.bits) || 0;
-        let commands: string[], alert: string;
-        if (CONFIG?.bits.matches && CONFIG.bits.matches[bits]) {
-          commands = CONFIG.bits.matches[bits].commands;
-          alert = CONFIG.bits.matches[bits].alert;
-        } else {
-          const key = bits < 100 ? '99orLess' : '100orMore';
-          commands = CONFIG.bits[key].commands;
-          alert = CONFIG.bits[key].alert;
-        }
-        if (commands) {
-          for (const cmd of commands) {
-            void services.twitchService.ownerRunCommand(cmd);
-          }
-        }
-        if (alert) {
-          await playAudioFile(alert);
-        }
+      let body: any = ctx.body;
+      // To test bits like: !bits 420
+      if (body.match(/^\d{1,4}$/g)) {
+        body = '{ "bits": ' + body + ' }';
+      }
+      body = JSON.parse(body);
+      const bits = parseInt(body.bits) || 0;
 
-        // Play a message after all the other alerts and sounds play
-        if (body?.message && bits >= 100) {
-          body.message = body.message.replace(/cheer\d{1,10}/gi, '').trim();
-          await services.twitchService.ownerRunCommand(`!tts ${body.message}`);
+      // If there's a user, add them to the contributions to thank them at the end of the stream
+      if (body.user) {
+        commandState.contributions[body.user] =
+          bits + (commandState.contributions[body.user] || 0);
+      }
+
+      let commands: string[], alert: string;
+      if (CONFIG?.bits.matches && CONFIG.bits.matches[bits]) {
+        commands = CONFIG.bits.matches[bits].commands;
+        alert = CONFIG.bits.matches[bits].alert;
+      } else {
+        const key = bits < 100 ? '99orLess' : '100orMore';
+        commands = CONFIG.bits[key].commands;
+        alert = CONFIG.bits[key].alert;
+      }
+      if (commands) {
+        for (const cmd of commands) {
+          void services.twitchService.ownerRunCommand(cmd);
         }
-      } catch (e) {
-        console.log('Error in bits command');
-        console.error(e);
+      }
+      if (alert) {
+        await playAudioFile(alert);
+      }
+
+      // Play a message after all the other alerts and sounds play
+      if (body?.message && bits >= 100) {
+        body.message = body.message.replace(/cheer\d{1,10}/gi, '').trim();
+        await services.twitchService.ownerRunCommand(`!tts ${body.message}`);
       }
     });
   }

--- a/src/command/owner-commands/buy.ts
+++ b/src/command/owner-commands/buy.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'buy',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     const square = ctx.args[0].trim().substring(0, 2).toLowerCase();

--- a/src/command/owner-commands/cban.ts
+++ b/src/command/owner-commands/cban.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'cban',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     const user = ctx.args[0]?.toLowerCase();

--- a/src/command/owner-commands/commercial.ts
+++ b/src/command/owner-commands/commercial.ts
@@ -3,15 +3,22 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'commercial',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
+    let length = 30;
+    if (ctx.args[0]) {
+      try {
+        length = parseInt(ctx.args[0]);
+      } catch (e) {
+        console.error('Error parsing commercial length. Setting to 30.', e);
+      }
+    }
     void services.twitchService.helixOwnerApiCall(
       'https://api.twitch.tv/helix/channels/commercial',
       'POST',
       {
         broadcaster_id: CONFIG.twitch.ownerId,
-        length: 90
+        length
       }
     );
     return true;

--- a/src/command/owner-commands/discordspeak.ts
+++ b/src/command/owner-commands/discordspeak.ts
@@ -3,7 +3,6 @@ import { CONFIG } from '../../config/config.service';
 
 const command: Command = {
   name: 'discordspeak',
-  ownerOnly: true,
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx, { services }) => {
     const msg = ctx.body;

--- a/src/command/owner-commands/end.ts
+++ b/src/command/owner-commands/end.ts
@@ -3,7 +3,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'end',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services, commandState }) => {
     commandState.isLive = false;

--- a/src/command/owner-commands/heartrate.ts
+++ b/src/command/owner-commands/heartrate.ts
@@ -3,7 +3,6 @@ import { CONFIG } from '../../config/config.service';
 
 const command: Command = {
   name: 'heartrate',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     if (!CONFIG.heartRate.enabled) {

--- a/src/command/owner-commands/kill.ts
+++ b/src/command/owner-commands/kill.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'kill',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     if (commandState.killedCommands.includes(ctx.args[0])) {

--- a/src/command/owner-commands/live.ts
+++ b/src/command/owner-commands/live.ts
@@ -11,7 +11,6 @@ import { CONFIG } from '../../config/config.service';
  */
 const command: Command = {
   name: 'live',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services, commandState }) => {
     let msg = ctx.body;

--- a/src/command/owner-commands/party.ts
+++ b/src/command/owner-commands/party.ts
@@ -6,7 +6,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'party',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/race.ts
+++ b/src/command/owner-commands/race.ts
@@ -3,7 +3,6 @@ import { Platform } from '../../enums';
 const command: Command = {
   name: 'race',
   aliases: ['racer'],
-  ownerOnly: true,
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx, { services }) => {
     try {

--- a/src/command/owner-commands/raids.ts
+++ b/src/command/owner-commands/raids.ts
@@ -8,7 +8,6 @@ const raidersConfig = CONFIG.raids.matches || {};
 
 const command: Command = {
   name: 'raids',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services, commandState }) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/recap.ts
+++ b/src/command/owner-commands/recap.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'recap',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     let res = await fetch(

--- a/src/command/owner-commands/resetlimits.ts
+++ b/src/command/owner-commands/resetlimits.ts
@@ -1,0 +1,19 @@
+import { Platform } from '../../enums';
+
+const command: Command = {
+  name: 'resetlimits',
+  platforms: [Platform.Twitch],
+  run: async (_ctx, { commandState }) => {
+    const command = _ctx.args[0]?.trim();
+    // If no command is specified, reset the limits on all commands
+    if (!command) {
+      commandState.limitedCommands = {};
+    } else {
+      // If a command is specified, reset the limits on that command
+      commandState.limitedCommands[command] = {};
+    }
+    return true;
+  }
+};
+
+export default command;

--- a/src/command/owner-commands/shortslist.ts
+++ b/src/command/owner-commands/shortslist.ts
@@ -39,7 +39,6 @@ async function getLastVideosByPlaylist(
 const command: Command = {
   name: 'shortslist',
   platforms: [Platform.Twitch, Platform.Discord],
-  ownerOnly: true,
   run: async (ctx) => {
     if (!CONFIG.youtube.enabled) {
       console.log('YouTube not enabled in config for !shortslist command');

--- a/src/command/owner-commands/sound.ts
+++ b/src/command/owner-commands/sound.ts
@@ -7,7 +7,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'sound',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/subs.ts
+++ b/src/command/owner-commands/subs.ts
@@ -5,7 +5,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'subs',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/suggest.ts
+++ b/src/command/owner-commands/suggest.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'suggest',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState, services }) => {
     if (!commandState.wouldBeCommands[ctx.body]) {

--- a/src/command/owner-commands/toggle.ts
+++ b/src/command/owner-commands/toggle.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'toggle',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     if (commandState.toggledOffCommands.includes(ctx.args[0])) {

--- a/src/command/owner-commands/train.ts
+++ b/src/command/owner-commands/train.ts
@@ -6,7 +6,6 @@ const queue = new FunctionQueue();
 
 const command: Command = {
   name: 'train',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { services }) => {
     return queue.enqueue(async function () {

--- a/src/command/owner-commands/twitchspeak.ts
+++ b/src/command/owner-commands/twitchspeak.ts
@@ -2,7 +2,6 @@ import { Platform } from '../../enums';
 
 const command: Command = {
   name: 'twitchspeak',
-  ownerOnly: true,
   platforms: [Platform.Twitch, Platform.Discord],
   run: async (ctx, { services }) => {
     const msg = ctx.body;

--- a/src/command/owner-commands/voice.ts
+++ b/src/command/owner-commands/voice.ts
@@ -3,7 +3,6 @@ import { CONFIG } from '../../config/config.service';
 
 const command: Command = {
   name: 'voice',
-  ownerOnly: true,
   platforms: [Platform.Twitch],
   run: async (ctx, { commandState }) => {
     const voice = ctx.args[0]?.toLowerCase().trim();

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -5,18 +5,18 @@ import { getRandomElement } from '../utils/utils';
 
 config();
 
-const kings = [];
-const crowns = [];
-const oppKings = [];
+const kings: string[] = [];
+const crowns: string[] = [];
+const oppKings: string[] = [];
 const themeConfig = {};
-const soundboard = [];
+const soundboard: string[] = [];
 
 [
   ['./public/images/kings', kings],
   ['./public/images/crowns', crowns],
   ['./public/images/opponents', oppKings],
   ['./public/sounds/soundboard', soundboard]
-].forEach((publicFiles: [string, any]) => {
+].forEach((publicFiles: [string, string[]]) => {
   readdirSync(publicFiles[0]).forEach((file) => {
     const fileName = file.split('.')[0];
     publicFiles[1].push(fileName);

--- a/src/lichess/lichess.service.ts
+++ b/src/lichess/lichess.service.ts
@@ -33,7 +33,7 @@ export class LichessService {
     }
   }
 
-  async getGameOpening(gameId: string): Promise<any> {
+  async getGameOpening(gameId: string): Promise<string> {
     try {
       const url = `https://lichess.org/game/export/${gameId}`;
       const res = await fetch(url, { headers: { Accept: 'application/json' } });

--- a/src/twitch/twitch.controller.ts
+++ b/src/twitch/twitch.controller.ts
@@ -5,34 +5,30 @@ import { configService, CONFIG } from '../config/config.service';
 @Controller('twitch')
 export class TwitchController {
   constructor(private readonly twitchService: TwitchService) {}
-  @Get('config')
-  getTwitchConfig(): any {
-    return {};
-  }
 
   @Get('kings')
-  getTwitchKings(): any {
+  getTwitchKings(): string[] {
     return configService.getKings();
   }
 
   @Get('opps')
-  getOpponentKings(): any {
+  getOpponentKings(): string[] {
     return configService.getOppKings();
   }
 
   @Get('crowns')
-  getTwitchCrowns(): any {
+  getTwitchCrowns(): string[] {
     return configService.getCrowns();
   }
 
   @Get('themeconfig')
-  getThemeConfig(): any {
+  getThemeConfig(): unknown {
     return configService.getThemeConfig();
   }
 
   // Load sounds for the soundboard menu
   @Get('soundboard')
-  getSoundboard(): any {
+  getSoundboard(): string[] {
     return configService.getSoundboard();
   }
 
@@ -42,7 +38,7 @@ export class TwitchController {
   }
 
   @Post('/command')
-  postOwnerRunCommand(@Body() body) {
+  postOwnerRunCommand(@Body() body: { command: string }) {
     void this.twitchService.ownerRunCommand(body.command);
   }
 

--- a/src/twitch/twitch.gateway.ts
+++ b/src/twitch/twitch.gateway.ts
@@ -26,29 +26,29 @@ export class TwitchGateway
   ) {}
 
   @SubscribeMessage('botSpeak')
-  handleMessage(client: any, payload: any) {
+  handleMessage(_client: Socket, payload: string) {
     this.twitchService.botSpeak(payload);
   }
 
   @SubscribeMessage('updateBoughtSquares')
-  handleUpdateBoughtSquares(client: any, payload: any) {
+  handleUpdateBoughtSquares(_client: Socket, payload: unknown) {
     this.twitchService.updateBoughtSquares(payload);
   }
 
-  afterInit(_server: any): any {
+  afterInit(_server: unknown) {
     this.logger.log('Initialized!');
   }
 
-  handleConnection(client: Socket, ..._args): any {
+  handleConnection(client: Socket) {
     this.logger.log(`Twitch-Socket Client connected: ${client.id}`);
     this.sockets.push(client);
   }
 
-  handleDisconnect(client: Socket): any {
+  handleDisconnect(client: Socket) {
     this.logger.log(`Twitch-Socket Client disconnected: ${client.id}`);
   }
 
-  public sendDataToSockets(event, data): any {
+  public sendDataToSockets(event: string, data: unknown) {
     this.logger.log(`Sending ${event} event to sockets.`);
     this.sockets.forEach((socket: Socket) => {
       if (socket.connected) {
@@ -57,7 +57,7 @@ export class TwitchGateway
     });
   }
 
-  public sendDataToOneSocket(event, data): any {
+  public sendDataToOneSocket(event: string, data: unknown) {
     this.logger.log(`Sending ${event} event to a single socket.`);
     for (let i = 0; i < this.sockets.length; i++) {
       if (this.sockets[i].connected) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -68,7 +68,7 @@ interface YAMLConfig {
       myOwnCommand: string;
     };
     followerCommands: string[];
-    subsCommands: string[];
+    subCommands: string[];
     limitedCommands: { [key: string]: number };
     userRestrictedCommands: {
       [key: string]: string[];


### PR DESCRIPTION
# Release Notes

### 1.1.2 (2023-12-30)

#### Bug Fixes

- There was at least one command in the `owner-commands` dir that I forgot to add `ownerOnly: true` to, so now all commands in the owner directory and mod directory will automatically get `ownerOnly: true` and `modOnly: true` respectively.
- Fix `any` usage in `command.types.d.ts` to properly type services in command files.
- Fix an issue with `!bits` where users weren't getting added to the contributions to be thanked at the end of the stream.
- Fix an issue with subCommands being wrong in the types file.

#### Features

- Added a `!resetlimits` owner command. Without an arg, it resets the limits on all commands. Or you can reset the limits on one command like `!resetlimits image`.
- Added a `!resign` command to tell the streamer it's time to end the madness. I added this as a user restricted command in the config.
